### PR TITLE
feat: add support for multiple moduleRoots. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Modules can still accessed via their index files, establishing a pattern of publ
 
 #### Options
 
-| Option     | type                          | description                                               | Ex                                        |
-| ---------- | ----------------------------- | --------------------------------------------------------- | ----------------------------------------- |
-| moduleRoot | string (path or glob pattern) | Sets the top level folder where a module may be accessed. | `**/packages/*` or `src/modules/myModule` |
+| Option     | type                                    | description                                               | Ex                                            |
+| ---------- | --------------------------------------- | --------------------------------------------------------- | --------------------------------------------- |
+| moduleRoot | array of strings (path or glob pattern) | Sets the top level folder where a module may be accessed. | `[**/packages/*]` or `[src/modules/myModule]` |
 
 #### Examples
 
@@ -36,7 +36,7 @@ And the .eslintrc file:
   ...
   "rules": {
     "import-extended/no-internal-from-external-modules": [ "error", {
-      "moduleRoot": "**/packages/*",
+      "moduleRoot": ["**/packages/*"],
     } ]
   }
 }

--- a/src/rules/no-internal-from-external-modules/no-internal-from-external-modules.test.ts
+++ b/src/rules/no-internal-from-external-modules/no-internal-from-external-modules.test.ts
@@ -30,7 +30,7 @@ ruleTester.run("no-internal-from-external-modules", rule, {
         {
             name: "Allow sibling import within internal module",
             code: 'import x from "./package-one-secret-sauce"',
-            options: [{moduleRoot: "**/packages/*"}],
+            options: [{moduleRoot: ["**/packages/*"]}],
             filename: testFilePath(
                 "no-internal-modules/src/packages/package-one/index.ts"
             ),
@@ -38,7 +38,7 @@ ruleTester.run("no-internal-from-external-modules", rule, {
         {
             name: "Allow sibling import within internal module's nested folder",
             code: 'import x from "../package-one-secret-sauce"',
-            options: [{moduleRoot: "**/packages/*"}],
+            options: [{moduleRoot: ["**/packages/*"]}],
             filename: testFilePath(
                 "no-internal-modules/src/packages/package-one/nested-folder/some-file.ts"
             ),
@@ -46,19 +46,19 @@ ruleTester.run("no-internal-from-external-modules", rule, {
         {
             name: "Allow importing index from external module",
             code: 'import x from "./packages/package-one"',
-            options: [{moduleRoot: "**/packages/*"}],
+            options: [{moduleRoot: ["**/packages/*"]}],
             filename: testFilePath("no-internal-modules/src/index.ts"),
         },
         {
             name: "Allow importing index directly from external module",
             code: 'import x from "./packages/package-one/index"',
-            options: [{moduleRoot: "**/packages/*"}],
+            options: [{moduleRoot: ["**/packages/*"]}],
             filename: testFilePath("no-internal-modules/src/index.ts"),
         },
         {
             name: "Ignore modules that are not specified as a root module",
             code: 'import x from "./common/some-common-file"',
-            options: [{moduleRoot: "**/packages/*"}],
+            options: [{moduleRoot: ["**/packages/*"]}],
             filename: testFilePath("no-internal-modules/src/index.ts"),
         },
     ],
@@ -69,7 +69,7 @@ ruleTester.run("no-internal-from-external-modules", rule, {
             filename: testFilePath(
                 "no-internal-modules/src/packages/package-one/index.ts"
             ),
-            options: [{moduleRoot: "**/packages/*"}],
+            options: [{moduleRoot: ["**/packages/*"]}],
             errors: [
                 {
                     messageId: "shouldUseExternal",
@@ -85,7 +85,7 @@ ruleTester.run("no-internal-from-external-modules", rule, {
                     messageId: "shouldUseExternal",
                 },
             ],
-            options: [{moduleRoot: "**/packages/*"}],
+            options: [{moduleRoot: ["**/packages/*"]}],
         },
         {
             name: "Disallow importing index that is not a modules root index",
@@ -96,13 +96,33 @@ ruleTester.run("no-internal-from-external-modules", rule, {
                     messageId: "shouldUseExternal",
                 },
             ],
-            options: [{moduleRoot: "**/packages/*"}],
+            options: [{moduleRoot: ["**/packages/*"]}],
         },
         {
             name: "Disallow importing files from an external package, if specified in options",
             code: 'import x from "@someCompany/external-package/internal-file"',
-            options: [{moduleRoot: "@someCompany/external-package"}],
+            options: [{moduleRoot: ["@someCompany/external-package"]}],
             filename: testFilePath("no-internal-modules/src/common/index.ts"),
+            errors: [
+                {
+                    messageId: "shouldUseExternal",
+                },
+            ],
+        },
+        {
+            name: "Should support disallowing via multiple options",
+            code: 'import {x} from "../package-two/package-two-secret-sauce"',
+            filename: testFilePath(
+                "no-internal-modules/src/packages/package-one/index.ts"
+            ),
+            options: [
+                {
+                    moduleRoot: [
+                        "@someCompany/external-package",
+                        "**/packages/*",
+                    ],
+                },
+            ],
             errors: [
                 {
                     messageId: "shouldUseExternal",

--- a/src/rules/no-internal-from-external-modules/no-internal-from-external-modules.ts
+++ b/src/rules/no-internal-from-external-modules/no-internal-from-external-modules.ts
@@ -31,7 +31,10 @@ export default createRule({
                 type: "object",
                 properties: {
                     moduleRoot: {
-                        type: "string",
+                        type: "array",
+                        items: {
+                            type: "string",
+                        },
                     },
                 },
                 additionalProperties: false,
@@ -41,17 +44,18 @@ export default createRule({
 
     create(
         context: Readonly<
-            TSESLint.RuleContext<"shouldUseExternal", {moduleRoot: string}[]>
+            TSESLint.RuleContext<"shouldUseExternal", {moduleRoot: string[]}[]>
         >
     ) {
         //----------------------------------------------------------------------
         // Options
         //----------------------------------------------------------------------
-        const genericModuleRootRegex = (context.options || []).map((option) =>
-            minimatch.makeRe(option.moduleRoot)
+        const moduleRoot = context.options[0].moduleRoot || [];
+        const genericModuleRootRegex = moduleRoot.map((root) =>
+            minimatch.makeRe(root)
         );
-        const genericModuleRootChildrenRegex = (context.options || []).map(
-            (option) => minimatch.makeRe(path.join(option.moduleRoot, "/**"))
+        const genericModuleRootChildrenRegex = moduleRoot.map((root) =>
+            minimatch.makeRe(path.join(root, "/**"))
         );
 
         //----------------------------------------------------------------------


### PR DESCRIPTION
Currently we only support a single moduleRoot. In this PR I introduce the ability to set an array of moduleRoots instead of a single root. 

Whats changed
* Updated docs to reflect always using an array for config
* Treat `context.options[0]` as the only option provided, and iterate over the module root instead. 
* Update tests to use an array for singular moduleRoot configs
* Add a test case to validate using multiple moduleRoots. 

 